### PR TITLE
Revert "Fix Pr #357"

### DIFF
--- a/docs/internal_api/index.rst
+++ b/docs/internal_api/index.rst
@@ -15,6 +15,7 @@ UxDataset
 The ``uxarray.UxDataset`` class inherits from ``xarray.Dataset``. Below is a list of
 features explicitly added to work on Unstructured Grids.
 
+
 Class
 -----
 .. autosummary::
@@ -29,6 +30,7 @@ Attributes
 
    UxDataset._source_datasets
    UxDataset._uxgrid
+
 
 Methods
 -------
@@ -56,12 +58,14 @@ Class
 
    UxDataArray
 
+
 Attributes
 ----------
 .. autosummary::
    :toctree: _autosummary
 
    UxDataArray._uxgrid
+
 
 Methods
 -------
@@ -71,7 +75,6 @@ Methods
    UxDataArray._construct_direct
    UxDataArray._copy
    UxDataArray._replace
-
 
 Grid
 ===========
@@ -108,15 +111,19 @@ Operators
    Grid.__eq__
    Grid.__ne__
 
-
 Helpers
-=======
+===========
 
 Connectivity
 ------------
 .. autosummary::
    :toctree: _autosummary
 
+<<<<<<< HEAD
+   utils.helpers._is_ugrid
+   utils.helpers._replace_fill_values
+   utils.helpers._angle_of_2_vectors
+=======
    grid.connectivity._replace_fill_values
    grid.connectivity._build_nNodes_per_face
    grid.connectivity._build_edge_node_connectivity
@@ -130,26 +137,10 @@ Coordinates
    grid.coordinates._populate_cartesian_xyz_coord
    grid.coordinates._populate_lonlat_coord
 
-Lines
------
-.. autosummary::
-   :toctree: _autosummary
-
-   grid.lines._angle_of_2_vectors
-
 IO
-==
-
-Ugrid
------
-.. autosummary::
-   :toctree: _autosummary
-
-   io._ugrid._is_ugrid
-
-Utils
------
+---
 .. autosummary::
    :toctree: _autosummary
 
    io.utils._parse_grid_type
+>>>>>>> main

--- a/docs/user_api/index.rst
+++ b/docs/user_api/index.rst
@@ -140,6 +140,22 @@ Face Area
 .. autosummary::
    :toctree: _autosummary
 
+<<<<<<< HEAD
+   calculate_face_area
+   calculate_spherical_triangle_jacobian
+   calculate_spherical_triangle_jacobian_barycentric
+   close_face_nodes
+   get_all_face_area_from_coords
+   get_gauss_quadratureDG
+   get_tri_quadratureDG
+   grid_center_lat_lon
+   node_xyz_to_lonlat_rad
+   node_lonlat_rad_to_xyz
+   normalize_in_place
+   parse_grid_type
+   is_between
+   point_within_GCA
+=======
    grid.area.calculate_face_area
    grid.area.get_all_face_area_from_coords
    grid.area.calculate_spherical_triangle_jacobian
@@ -164,14 +180,6 @@ Coordinates
    grid.coordinates.normalize_in_place
    grid.coordinates.grid_center_lat_lon
 
-Lines
------
-.. autosummary::
-   :toctree: _autosummary
-
-   grid.lines.is_between
-   grid.lines.point_within_GCA
-
 Numba
 -----
 .. autosummary::
@@ -181,3 +189,4 @@ Numba
    utils.disable_jit_cache
    utils.enable_jit
    utils.disable_jit
+>>>>>>> main

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -280,4 +280,5 @@ class TestIntersectionPoint(TestCase):
         with self.assertRaises(ValueError):
             point_within_GCA(pt_cart, gcr_cart)
         gcr_car_flipped = np.array([v2_cart, v1_cart])
-        self.assertTrue(point_within_GCA(pt_cart, gcr_car_flipped))
+        self.assertTrue(
+            point_within_GCA(pt_cart, gcr_car_flipped))

--- a/uxarray/grid/coordinates.py
+++ b/uxarray/grid/coordinates.py
@@ -1,3 +1,4 @@
+import numpy
 import xarray as xr
 import numpy as np
 import math
@@ -21,7 +22,7 @@ def node_lonlat_rad_to_xyz(node_coord):
 
     Returns
     ----------
-    float list
+    float numpy.array
         the result array of the unit 3D coordinates [x, y, z] vector where :math:`x^2 + y^2 + z^2 = 1`
 
     Raises
@@ -29,12 +30,16 @@ def node_lonlat_rad_to_xyz(node_coord):
     RuntimeError
         The input array doesn't have the size of 3.
     """
-    if len(node_coord) != 2:
+    node_coord = np.asarray(node_coord, dtype=np.float64)
+    if node_coord.size != 2:
         raise RuntimeError(
             "Input array should have a length of 2: [longitude, latitude]")
     lon = node_coord[0]
     lat = node_coord[1]
-    return [np.cos(lon) * np.cos(lat), np.sin(lon) * np.cos(lat), np.sin(lat)]
+    return np.array(
+        [np.cos(lon) * np.cos(lat),
+         np.sin(lon) * np.cos(lat),
+         np.sin(lat)])
 
 
 @njit(cache=ENABLE_JIT_CACHE)
@@ -49,7 +54,7 @@ def node_xyz_to_lonlat_rad(node_coord):
 
     Returns
     ----------
-    float list
+    float np.array
         the result array of longitude and latitude in radian [longitude_rad, latitude_rad]
 
     Raises
@@ -57,9 +62,9 @@ def node_xyz_to_lonlat_rad(node_coord):
     RuntimeError
         The input array doesn't have the size of 3.
     """
-    if len(node_coord) != 3:
+    node_coord = np.asarray(node_coord, dtype=np.float64)
+    if node_coord.size != 3:
         raise RuntimeError("Input array should have a length of 3: [x, y, z]")
-
     [dx, dy, dz] = normalize_in_place(node_coord)
     dx /= np.absolute(dx * dx + dy * dy + dz * dz)
     dy /= np.absolute(dx * dx + dy * dy + dz * dz)
@@ -78,7 +83,7 @@ def node_xyz_to_lonlat_rad(node_coord):
         d_lon_rad = 0.0
         d_lat_rad = -0.5 * np.pi
 
-    return [d_lon_rad, d_lat_rad]
+    return np.array([d_lon_rad, d_lat_rad])
 
 
 @njit(cache=ENABLE_JIT_CACHE)
@@ -102,10 +107,11 @@ def normalize_in_place(node):
     RuntimeError
         The input array doesn't have the size of 3.
     """
-    if len(node) != 3:
+    node = np.asarray(node, dtype=np.float64)
+    if node.size != 3:
         raise RuntimeError("Input array should have a length of 3: [x, y, z]")
 
-    return np.array(node) / np.linalg.norm(np.array(node), ord=2)
+    return node / np.linalg.norm(np.array(node), ord=2)
 
 
 def grid_center_lat_lon(ds):

--- a/uxarray/grid/lines.py
+++ b/uxarray/grid/lines.py
@@ -5,17 +5,6 @@ from uxarray.grid.coordinates import node_xyz_to_lonlat_rad
 from uxarray.constants import ERROR_TOLERANCE
 
 
-def convert_to_list_if_needed(obj):
-    if not isinstance(obj, list):
-        if isinstance(obj, np.ndarray):
-            # Convert the NumPy array to a list using .tolist()
-            obj = obj.tolist()
-        else:
-            # If not a list or NumPy array, return the object as-is
-            obj = [obj]
-    return obj
-
-
 def point_within_GCA(pt, gca_cart):
     """Check if a point lies on a given Great Circle Arc (GCA). The anti-
     meridian case is also considered.
@@ -56,15 +45,9 @@ def point_within_GCA(pt, gca_cart):
     """
     # Convert the cartesian coordinates to lonlat coordinates, the node_xyz_to_lonlat_rad is already overloaded
     # with gmpy2 data type
-    pt_lonlat = node_xyz_to_lonlat_rad(convert_to_list_if_needed(pt))
-    GCRv0_lonlat = node_xyz_to_lonlat_rad(convert_to_list_if_needed(
-        gca_cart[0]))
-    GCRv1_lonlat = node_xyz_to_lonlat_rad(convert_to_list_if_needed(
-        gca_cart[1]))
-
-    # Convert the list to np.float64
-    gca_cart[0] = np.array(gca_cart[0], dtype=np.float64)
-    gca_cart[1] = np.array(gca_cart[1], dtype=np.float64)
+    pt_lonlat = node_xyz_to_lonlat_rad(pt)
+    GCRv0_lonlat = node_xyz_to_lonlat_rad(gca_cart[0])
+    GCRv1_lonlat = node_xyz_to_lonlat_rad(gca_cart[1])
 
     # First if the input GCR is exactly 180 degree, we throw an exception, since this GCR can have multiple planes
     angle = _angle_of_2_vectors(gca_cart[0], gca_cart[1])


### PR DESCRIPTION
Reverts hongyuchen1030/uxarray#3

This fix overwrites all the latest implementations for the coordinates conversion. The numba issues caused by the `return np.array` of the latest coordinates conversion function still exist.